### PR TITLE
refactor: replace lodash each with forEach

### DIFF
--- a/src/package-walk.js
+++ b/src/package-walk.js
@@ -5,7 +5,7 @@ import findRoot from 'find-root'
 import requirePackage from './require-package'
 
 function walkDeps (deps, it, root) {
-  _.each(deps, (__, name) => {
+  _.forEach(deps, (__, name) => {
     let depPath
     try {
       depPath = resolve.sync(name, {


### PR DESCRIPTION
The Lodash each method appears to be aliased. I'm not sure if it's going to be deprecated or not. This pull request simply replaces the each with forEach.

