### PR TITLE
Adding defaultEngines: option for default transpile or not #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ even if it doesn't otherwise meet transpilation criteria.
 Optional. This optionally overrides the `engines` key in your `package.json`.
 Or set to `false` to suppress any use of your `engines` for determining dependencies to transpile.
 
+#### `defaultEngines`
+
+`?object | ?boolean`
+
+Optional. Default is `false`.
+This optionally provides the `engines` key when missing from any dependencies.
+For example, `exclude({ defaultEngines: { 'node': '>= 4' } })` will assume that
+dependencies without `engines` require node 4, and determine transpilation normally.
+Or set to `true` to enable transpilation for dependencies without enough information.
+For example, `exclude({ defaultEngines: true })`.
+
 ## Issues
 
 * https://github.com/webpack/webpack/issues/2031

--- a/src/index.js
+++ b/src/index.js
@@ -15,14 +15,22 @@ export function getPluginsThatDontSatisfyModuleRange (plugins, range) {
   return _.pickBy(plugins, ({ node }) => !semver.satisfies(normalizeSemver(node), range))
 }
 
-export function getModuleNeedsBabel (pkg, { hasEsNextInMainFields, hostEngines } = {}) {
-  const { engines } = pkg
+export function getModuleNeedsBabel (pkg, { hasEsNextInMainFields, hostEngines, defaultEngines } = {}) {
+  let { engines } = pkg
   const hasEsNextField = getHasESNextField(Object.keys(pkg))
   // always transpile if we have an esnext field
   if (hasEsNextInMainFields && hasEsNextField) {
     return true
   }
-  if (!engines) return false
+  if (!engines) {
+    if (defaultEngines) {
+      if (typeof defaultEngines !== 'object') {
+        return true
+      }
+      engines = defaultEngines
+    }
+    return false
+  }
   const range = engines.node
   if (!range) return false
   if (range === '*') return false


### PR DESCRIPTION
This addresses issue #6 by providing defaultEngines as either a replacement for missing 'engines' or as 'true' to force transpilation.