### PR TITLE
fix: skip transpile plugins without Node support

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -5,6 +5,7 @@ import {
   exclude,
   include,
   getModuleNeedsBabel,
+  getPluginSatisfiesModuleRange,
   getNeedBabelFromPackageAndDependencies,
   getHasESNextInMainFields,
   getHasESNextField,
@@ -100,6 +101,47 @@ describe('index', () => {
         getModuleNeedsBabel({
           name: 'foo'
         })
+      ).toEqual(false)
+    })
+  })
+
+  describe('getPluginSatisfiesModuleRange', () => {
+    it('satisfies for plugins with no Node support', () => {
+      expect(
+        getPluginSatisfiesModuleRange(
+          {
+            chrome: '80',
+            firefox: '72',
+            opera: '67'
+          },
+          '>10'
+        )
+      ).toEqual(true)
+    })
+    it('satisfies for plugins with higher Node version', () => {
+      expect(
+        getPluginSatisfiesModuleRange(
+          {
+            chrome: '80',
+            firefox: '72',
+            opera: '67',
+            node: '12'
+          },
+          '>10'
+        )
+      ).toEqual(true)
+    })
+    it('does not satisfy for plugins with lower Node version', () => {
+      expect(
+        getPluginSatisfiesModuleRange(
+          {
+            chrome: '80',
+            firefox: '72',
+            opera: '67',
+            node: '8'
+          },
+          '>10'
+        )
       ).toEqual(false)
     })
   })

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,18 @@ import {
 } from './node-modules-regex'
 import normalizeSemver from './semver-normalize'
 
+export function getPluginSatisfiesModuleRange(plugin, range) {
+  const { node } = plugin
+  if (!node) {
+    return true
+  }
+  return semver.satisfies(normalizeSemver(node), range)
+}
+
 export function getPluginsThatDontSatisfyModuleRange(plugins, range) {
   return _.pickBy(
     plugins,
-    ({ node }) => !semver.satisfies(normalizeSemver(node), range)
+    plugin => !getPluginSatisfiesModuleRange(plugin, range)
   )
 }
 


### PR DESCRIPTION
It was reported in #22 that we throw errors for recent plugin additions to `@babel/compat-data` like `proposal-nullish-coalescing-operator` and `proposal-optional-chaining` that specify no supported Node versions.

For now, we'll assume we can skip considering transpilation for such plugins with the hope that nobody is publishing `main` scripts to `npm` that rely on these syntax features, since no versions of Node support them.

In the future we can consider adding an option to control whether or not these are transpiled, and perhaps also for which plugins (#7).