### PR TITLE
build: don't minify

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -9,6 +9,9 @@ export default {
   },
   target: 'node',
   externals: [nodeExternals()],
+  optimization: {
+    minimize: false
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
No need to minify the build since it's a dev tool running locally in Node. Suggested by @siilike here https://github.com/AndersDJohnson/webpack-babel-env-deps/issues/22#issuecomment-576877535.