### PR TITLE
fix: back to @babel/preset-env/data/plugins but as peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "dependency"
   ],
   "peerDependencies": {
-    "@babel/compat-data": "^7.8.1"
+    "@babel/preset-env": "^7"
   }
 }

--- a/src/__fixtures__/modules.txt
+++ b/src/__fixtures__/modules.txt
@@ -1,1 +1,1 @@
-find-up|load-json-file|locate-path|p-limit|p-locate|path-exists|path-type|pkg-dir|read-pkg|read-pkg-up|resolve-pkg|strip-bom|webpack-babel-env-deps
+find-up|load-json-file|locate-path|p-limit|p-locate|p-try|path-exists|path-type|pkg-dir|read-pkg|read-pkg-up|resolve-pkg|strip-bom|webpack-babel-env-deps

--- a/src/__fixtures__/modules.txt
+++ b/src/__fixtures__/modules.txt
@@ -1,1 +1,1 @@
-find-up|load-json-file|locate-path|p-limit|p-locate|p-try|path-exists|path-type|pkg-dir|read-pkg|read-pkg-up|resolve-pkg|strip-bom|webpack-babel-env-deps
+find-up|load-json-file|locate-path|p-limit|p-locate|path-exists|path-type|pkg-dir|read-pkg|read-pkg-up|resolve-pkg|strip-bom|webpack-babel-env-deps


### PR DESCRIPTION
Switch back to using `@babel/preset-env` instead of `@babel/compat-data` (#24), but this time as a peer dependency.