### PR TITLE
fix: import from @babel/preset-env/data/plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import semver from 'semver'
 import debug from 'debug'
 import readPkgUp from 'read-pkg-up'
-import plugins from '@babel/compat-data/plugins'
+import plugins from '@babel/preset-env/data/plugins'
 import semverMinForRange from './semver-min-for-range'
 import getDependencies from './get-dependencies'
 import {


### PR DESCRIPTION
This was supposed to go in with #26.