### PR TITLE
build: travis node 8 to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - node
-  - "8"
+  - "10"
 sudo: false


### PR DESCRIPTION
Updating Travis Node version from 8 to 10 since newer Jest requires Node 10 in https://github.com/AndersDJohnson/webpack-babel-env-deps/pull/41.