### PR TITLE
docs: note on uglify example vs. terser

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,7 @@ This mainly aims to solve errors during minification in production builds, since
 are unsupported by the
 [native UglifyJS webpack plugin](https://github.com/webpack-contrib/uglifyjs-webpack-plugin) through at least `3.x`.
 See [issues](#issues) below for examples of this error and affected modules.
+**Update: Webpack new uses Terser rather than Uglify for minification - this example may no longer be valid.**
 
 This module generates regular expressions to be used in the `exclude` or `include` properties
 of your [`babel-loader`][babel-loader] rule in your configuration.


### PR DESCRIPTION
Updates the note on Uglify given Webpack uses Terser now.