### PR TITLE
fix: support invalid package versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,8 @@ export function getHasESNextInMainFields(options = {}) {
 export function getNeedBabel(options) {
   const pathInPkg = options.path || process.cwd()
   const pkg = readPkgUp.sync({
-    cwd: pathInPkg
+    cwd: pathInPkg,
+    normalize: false // Support projects with invalid package versions.
   })
 
   const dependencies = getDependencies(pathInPkg, options)


### PR DESCRIPTION
Fixes https://github.com/AndersDJohnson/webpack-babel-env-deps/issues/51.
I believe root cause is `normalize-package-data`, depended on by `read-pkg` (via `read-pkg-up`), is requiring a valid version:
https://github.com/npm/normalize-package-data/blob/f2373b1bb423bb390e331658ed696483c6418d69/lib/fixer.js#L190-L192
See bug report https://github.com/npm/normalize-package-data/issues/116.
I think for now if we ask `read-pkg-up` not to normalize, that might fix it.