### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndersDJohnson/webpack-babel-env-deps/security/code-scanning/1](https://github.com/AndersDJohnson/webpack-babel-env-deps/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves existing behavior (checkout and test execution) while ensuring `GITHUB_TOKEN` cannot silently inherit broader write scopes from repo/org defaults. No imports, methods, or external definitions are needed—just YAML key insertion near the top of the workflow, after the `on` section (or before `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
